### PR TITLE
Complete assigment

### DIFF
--- a/src/main/java/com/harper/asteroids/App.java
+++ b/src/main/java/com/harper/asteroids/App.java
@@ -39,14 +39,16 @@ public class App {
 
     private Client client;
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = new ObjectMapper()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    public static ObjectMapper getObjectMapper() {
+        return mapper;
+    }
 
     public App() {
-
-
         ClientConfig configuration = new ClientConfig();
         client = ClientBuilder.newClient(configuration);
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     /**
@@ -63,7 +65,6 @@ public class App {
                 .get();
         System.out.println("Got response: " + response);
         if(response.getStatus() == Response.Status.OK.getStatusCode()) {
-            ObjectMapper mapper = new ObjectMapper();
             String content = response.readEntity(String.class);
 
 

--- a/src/main/java/com/harper/asteroids/ApproachDetector.java
+++ b/src/main/java/com/harper/asteroids/ApproachDetector.java
@@ -22,7 +22,7 @@ public class ApproachDetector {
     private static final String NEO_URL = "https://api.nasa.gov/neo/rest/v1/neo/";
     private List<String> nearEarthObjectIds;
     private Client client;
-    private ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = App.getObjectMapper();
 
     public ApproachDetector(List<String> ids) {
         this.nearEarthObjectIds = ids;

--- a/src/main/java/com/harper/asteroids/ApproachDetector.java
+++ b/src/main/java/com/harper/asteroids/ApproachDetector.java
@@ -53,6 +53,11 @@ public class ApproachDetector {
         return getClosest(neos, limit, startDate, endDate);
     }
 
+    /**
+     * Query a NEO from the NASA API by id
+     * @param id the id of the NEO
+     * @return The NearEarthObject corresponding to the given id
+     */
     private NearEarthObject queryNearEarthObjectById(String id) {
         System.out.println("Check passing of object " + id);
         try {
@@ -88,6 +93,13 @@ public class ApproachDetector {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Check if the closeApproachDate in closeApproachData is withing the startDate - endDate interval
+     * @param closeApproachData
+     * @param startDate the start of the time period
+     * @param endDate the end of the time period
+     * @return whether the date of the approach is within the given interval
+     */
     public static boolean isCloseApproachDateWithinInterval(CloseApproachData closeApproachData, LocalDate startDate, LocalDate endDate) {
         LocalDate closeApproachLocalDate = closeApproachData.getCloseApproachDate()
                 .toInstant().atZone(ZoneId.of("UTC")).toLocalDate();

--- a/src/main/java/com/harper/asteroids/model/CloseApproachData.java
+++ b/src/main/java/com/harper/asteroids/model/CloseApproachData.java
@@ -1,12 +1,10 @@
 package com.harper.asteroids.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Date;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CloseApproachData {
 
     @JsonProperty("close_approach_date")

--- a/src/main/java/com/harper/asteroids/model/Feed.java
+++ b/src/main/java/com/harper/asteroids/model/Feed.java
@@ -1,6 +1,5 @@
 package com.harper.asteroids.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -10,7 +9,6 @@ import java.util.stream.Collectors;
 /**
  * Response for a feed query of Neos.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Feed {
     @JsonProperty("element_count")
     private int elementCount;

--- a/src/main/java/com/harper/asteroids/model/NearEarthObject.java
+++ b/src/main/java/com/harper/asteroids/model/NearEarthObject.java
@@ -1,16 +1,12 @@
 package com.harper.asteroids.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
 /**
  * Definition for Neo - Near Earth Object
- *
- * TODO: why the h*** must I add this annotation to ignore unknown properties when I set it on ObjectMapper?
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class NearEarthObject {
 
     @JsonProperty("id")

--- a/src/main/java/com/harper/asteroids/model/NearEarthObjectIds.java
+++ b/src/main/java/com/harper/asteroids/model/NearEarthObjectIds.java
@@ -1,9 +1,7 @@
 package com.harper.asteroids.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class NearEarthObjectIds {
 
     @JsonProperty("id")

--- a/src/test/java/com/harper/asteroids/TestApproachDetector.java
+++ b/src/test/java/com/harper/asteroids/TestApproachDetector.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 
 public class TestApproachDetector {
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = App.getObjectMapper();
     private NearEarthObject neo1, neo2;
 
     @Before

--- a/src/test/java/com/harper/asteroids/TestApproachDetector.java
+++ b/src/test/java/com/harper/asteroids/TestApproachDetector.java
@@ -1,37 +1,52 @@
 package com.harper.asteroids;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.harper.asteroids.model.CloseApproachData;
 import com.harper.asteroids.model.NearEarthObject;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
 
 public class TestApproachDetector {
 
     private static final ObjectMapper mapper = App.getObjectMapper();
     private NearEarthObject neo1, neo2;
+    private LocalDate today;
 
     @Before
     public void setUp() throws IOException {
         neo1 = mapper.readValue(getClass().getResource("/neo_example.json"), NearEarthObject.class);
         neo2 = mapper.readValue(getClass().getResource("/neo_example2.json"), NearEarthObject.class);
+        today = LocalDate.of(2020, 1, 1);
+    }
 
+    @Test
+    public void testDateComparison() {
+        CloseApproachData data = neo1.getCloseApproachData().get(0);
+        // Approach is inside 1-week period
+        assertTrue(ApproachDetector.isCloseApproachDateWithinInterval(data,  LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 1).plusWeeks(1)));
+        // Start date overlaps with approach
+        assertTrue(ApproachDetector.isCloseApproachDateWithinInterval(data, LocalDate.of(2020, 1, 1),  LocalDate.of(2020, 1, 1)));
+        // End date overlaps with approach
+        assertTrue(ApproachDetector.isCloseApproachDateWithinInterval(data, LocalDate.of(2019, 12, 31), LocalDate.of(2020, 1, 1)));
+        // Approach is before period
+        assertFalse(ApproachDetector.isCloseApproachDateWithinInterval(data, LocalDate.of(2019, 12, 30), LocalDate.of(2019, 12, 31)));
+        // Invalid interval (end is before start)
+        assertFalse(ApproachDetector.isCloseApproachDateWithinInterval(data,  LocalDate.of(2020, 1, 2),  LocalDate.of(2019, 12, 31)));
     }
 
     @Test
     public void testFiltering() {
-
         List<NearEarthObject> neos = List.of(neo1, neo2);
-        List<NearEarthObject> filtered = ApproachDetector.getClosest(neos, 1);
-        //Neo2 has the closest passing at 5261628 kms away.
-        // TODO: Neo2's closest passing is in 2028.
-        // In Jan 202, neo1 is closer (5390966 km, vs neo2's at 7644137 km)
+        List<NearEarthObject> filtered = ApproachDetector.getClosest(neos, 1, today, today.plusWeeks(1));
+        // In Jan 2020, neo1 is closer (5390966 km, vs neo2's at 7644137 km)
         assertEquals(1, filtered.size());
-        assertEquals(neo2, filtered.get(0));
-
+        assertEquals(neo1, filtered.get(0));
     }
 }

--- a/src/test/java/com/harper/asteroids/TestVicinityComparator.java
+++ b/src/test/java/com/harper/asteroids/TestVicinityComparator.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.*;
 
 public class TestVicinityComparator {
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = App.getObjectMapper();
     private NearEarthObject neo1, neo2;
 
     @Before

--- a/src/test/java/com/harper/asteroids/model/TestParsing.java
+++ b/src/test/java/com/harper/asteroids/model/TestParsing.java
@@ -2,6 +2,7 @@ package com.harper.asteroids.model;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.harper.asteroids.App;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -13,7 +14,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class TestParsing {
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = App.getObjectMapper();
 
 
     @Before


### PR DESCRIPTION
**Assignment**
Your assignment is to 
1. Review the code. What works and what doesn't?

    - Missing null check for NEO responses.
    - The use of non-zoned date objects may cause issues (NASA API does not specify timezone, assumed UTC, this may be incorrect, would need to research it more).
    - Static code check / linter may improve code quality.
    - Dependencies should be scanned for security vulnerabilities and available updates.

2. There are some TODOs in the code: The original developer was frustrated that even if he configured object mapper to NOT fail on unknown properties, decoding did fail. He also had to add the annotation 
```@JsonIgnoreProperties(ignoreUnknown = true)``` to have jacksons mapper accept unknown properties. Only one of these approaches should be enough. Can you find the reason?

    - The `ObjectMapper` instance was overwritten with every declaration, so the configuration was never actually set for the mappers. The solution is to use a static variable for the mapper.
    - See commit: [Fix Jackson issues by making ObjectMapper static](https://github.com/nemkrisz11/asteroids/commit/3ae48bfd1d9410d1c86f92cf1d8d7815a9d20c66)

3. The asteroids are supposedly sorted so only the 10 closest passings are shown. However the data structure is such that each asteroid has a list of passings (CloseApproachData), with time, velocity and distance from earth. The sorting is only judging distance, even if that passing occured a century ago. Can you rework the sort algorithm so that the 10 closest passings the coming week is shown? (see TODO in ApproachDetector, #65 and corresponding test class)

    - We can filter the `CloseApproachData` date stamps for each `NearEarthObject` before sorting (it also makes the sorting faster).
    - See commit: [Rework approach filtering to support date periods](https://github.com/nemkrisz11/asteroids/commit/07ca3dc1ad8961cd9e13300d9973fc41c3bc6641)

4. Once the list of asteroid IDs are found, the asteroid data is retrieved sequentially, which can take significant time. If all these secondary queries were performed in parallel the program would appear faster. Can you rework this?
   (if you don't have time to code this then prepare some design sketch and prepare for a discussion around parallel queries.)  
   
    - We can use `CompletableFuture` for parallelizing the API requests in an elegant way.
    - See commit: [Send API requests in parallel using futures when querying NEOs](https://github.com/nemkrisz11/asteroids/commit/ea8429cec266cc149876d7f7457e3d41098bd79c)